### PR TITLE
Override metadata sync interval

### DIFF
--- a/resources/restate-server-s3-metadata.toml
+++ b/resources/restate-server-s3-metadata.toml
@@ -8,6 +8,7 @@ default-replication = 2
 
 [admin]
 heartbeat-interval = "1s"
+metadata-sync-interval = "1s"
 log-trim-check-interval = "5s"
 log-tail-update-interval = "3s"
 

--- a/resources/restate-server.toml
+++ b/resources/restate-server.toml
@@ -8,6 +8,7 @@ default-replication = 2
 
 [admin]
 heartbeat-interval = "1s"
+metadata-sync-interval = "1s"
 log-trim-check-interval = "5s"
 log-tail-update-interval = "3s"
 


### PR DESCRIPTION
This setting does not address the root cause of over-eager admin and naive failure detector, but is helpful for avoiding getting stuck after network partitions.