### PR TITLE
Drive Jepsen runs via external dispatch instead of native cron

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       ref:
@@ -29,7 +27,7 @@ on:
       testConfig:
         description: "Test configuration parameters"
         required: false
-        default: '{"workloads": "set-vo set-mds set-mds-s3 set-mds-ddb", "nemeses": "partition-random-node", "duration": "60", "rate": "100", "concurrency": "5n", "testCount": "5"}'
+        default: '{"workloads": "set-vo set-mds set-mds-s3 set-mds-ddb", "nemeses": "partition-random-node", "duration": "60", "rate": "100", "concurrency": "5n", "testCount": "20"}'
       clusterName:
         description: "Jepsen workers cluster AWS stack name"
         required: false
@@ -77,7 +75,7 @@ jobs:
           restateImageId: ${{ inputs.restateImageId }}
           restatePr: ${{ inputs.restatePr }}
           restateCommit: ${{ inputs.restateCommit }}
-          testConfig: ${{ inputs.testConfig || (github.event_name == 'schedule' && '{"workloads":"set-vo set-mds set-mds-s3 set-mds-ddb","nemeses":"partition-random-node","duration":"60","rate":"100","concurrency":"5n","testCount":"20"}') || '{"workloads":"set-vo set-mds set-mds-s3 set-mds-ddb","nemeses":"partition-random-node","duration":"60","rate":"100","concurrency":"5n","testCount":"5"}' }}
+          testConfig: ${{ inputs.testConfig || '{"workloads":"set-vo set-mds set-mds-s3 set-mds-ddb","nemeses":"partition-random-node","duration":"60","rate":"100","concurrency":"5n","testCount":"5"}' }}
           retainCluster: ${{ inputs.retainCluster || '"false"' }}
 
       - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
GitHub auto-disables scheduled workflows in public repos after 60 days of no repository activity. This low-activity repo kept hitting that limit (the workflow was last disabled as `disabled_inactivity`), so the nightly run silently stopped.

Remove the `schedule` trigger so the workflow is no longer subject to inactivity-disabling and stays permanently dispatchable. The nightly run is now driven via `workflow_dispatch` from an always-active repo. Make the dispatch default the heavy nightly config (testCount 20) so a no-input dispatch reproduces the previous scheduled behavior; push/PR events keep the light config (testCount 5).