### PR TITLE
Use new /restate/call ingress API in service workloads

### DIFF
--- a/src/restate/jepsen/register_virtual_object.clj
+++ b/src/restate/jepsen/register_virtual_object.clj
@@ -9,7 +9,7 @@
 
 (ns restate.jepsen.register-virtual-object
   "A CAS register service client implemented as a Restate Virtual Object.
-  Uses regular HTTP ingress and requires the Register service to be deployed."
+  Uses the versioned /restate/call HTTP ingress API and requires the Register service to be deployed."
   (:require
    [clojure.tools.logging :refer [info]]
    [jepsen [client :as client]
@@ -37,32 +37,32 @@
 
  (setup! [this _test]
    (info "Using service URL" (:ingress-url this))
-   (util/await-fn (fn [] (->> (hc/get (str (:ingress-url this) "/Register/0/get") (:defaults this))
+   (util/await-fn (fn [] (->> (hc/get (str (:ingress-url this) "/restate/call/Register/0/get") (:defaults this))
                               (:status)
                               (= 200))))
    (when (:dummy? (:ssh opts))
      (doseq [k (range 5)]
-       (hc/post (str (:ingress-url this) "/Register/" k "/clear") (:defaults this)))))
+       (hc/post (str (:ingress-url this) "/restate/call/Register/" k "/clear") (:defaults this)))))
 
  (invoke! [this _test op]
    (let [[k v] (:value op)]
      (try+
       (case (:f op)
         :read (let [value
-                    (->> (hc/get (str (:ingress-url this) "/Register/" k "/get")
+                    (->> (hc/get (str (:ingress-url this) "/restate/call/Register/" k "/get")
                                  (:defaults this))
                          (:body)
                          (parse-long-nil))]
                 (assoc op :type :ok :value (independent/tuple k value) :node (:node this)))
 
-        :write (do (hc/post (str (:ingress-url this) "/Register/" k "/set")
+        :write (do (hc/post (str (:ingress-url this) "/restate/call/Register/" k "/set")
                             (merge (:defaults this)
                                    {:body (json/generate-string v)
                                     :content-type :json}))
                    (assoc op :type :ok :node (:node this)))
 
         :cas (let [[old new] v]
-               (hc/post (str (:ingress-url this) "/Register/" k "/cas")
+               (hc/post (str (:ingress-url this) "/restate/call/Register/" k "/cas")
                         (merge (:defaults this)
                                {:body (json/generate-string {:expected old :newValue new})
                                 :content-type :json}))

--- a/src/restate/jepsen/set_virtual_object.clj
+++ b/src/restate/jepsen/set_virtual_object.clj
@@ -9,7 +9,7 @@
 
 (ns restate.jepsen.set-virtual-object
   "A set service client backed by a Restate Virtual Object.
-  Uses regular HTTP ingress and requires the Set service to be deployed."
+  Uses the versioned /restate/call HTTP ingress API and requires the Set service to be deployed."
   (:require
    [cheshire.core :as json]
    [clojure.tools.logging :refer [info]]
@@ -36,26 +36,26 @@
           :defaults (hu/defaults hu/client)))
 
  (setup! [this _test]
-   (info "Using service URL" (str (:ingress-url this) "/Set/"))
+   (info "Using service URL" (str (:ingress-url this) "/restate/call/Set/"))
    (util/await-fn (fn [] (->> (with-retry
-                                #(hc/get (str (:ingress-url this) "/Set/" key "/get") (:defaults this)))
+                                #(hc/get (str (:ingress-url this) "/restate/call/Set/" key "/get") (:defaults this)))
                               (:status)
                               (= 200))))
    (when (:dummy? (:ssh opts))
      (with-retry
-       #(hc/post (str (:ingress-url this) "/Set/" key "/clear") (:defaults this)))))
+       #(hc/post (str (:ingress-url this) "/restate/call/Set/" key "/clear") (:defaults this)))))
 
  (invoke! [this _test op]
    (try+
     (case (:f op)
       :read (assoc op :type :ok  :value
-                   (->> (hc/post (str (:ingress-url this) "/Set/" key "/get")
+                   (->> (hc/post (str (:ingress-url this) "/restate/call/Set/" key "/get")
                                  (:defaults this))
                         (:body)
                         (json/parse-string))
                    :node (:node this))
 
-      :add (do (hc/post (str (:ingress-url this) "/Set/" key "/add")
+      :add (do (hc/post (str (:ingress-url this) "/restate/call/Set/" key "/add")
                         (merge (:defaults this)
                                {:body (json/generate-string (:value op))}))
                (assoc op :type :ok :node (:node this))))

--- a/src/restate/util.clj
+++ b/src/restate/util.clj
@@ -116,7 +116,7 @@
               (throw+ {:type :service-deployments-not-ready}))))
 
   (info "Waiting for service to become callable...")
-  (await-url "http://localhost:8080/Set/0/get"))
+  (await-url "http://localhost:8080/restate/call/Set/0/get"))
 
 (defn restate-server-node-count [opts] (- (count (:nodes opts)) (:dedicated-service-nodes opts)))
 


### PR DESCRIPTION
Migrate the Register and Set virtual-object workloads (and the deployment readiness check) from the old unversioned ingress paths (/{Service}/{key}/{handler}) to the new versioned ingress API (/restate/call/{service}/{key}/{handler}).

Closes #25